### PR TITLE
Covid updates command

### DIFF
--- a/Models/CovidData.cs
+++ b/Models/CovidData.cs
@@ -1,0 +1,73 @@
+﻿using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace CouchBot.UserCommands.Models
+{
+    public class CovidData
+    {
+        [JsonProperty("updated")]
+        public long Updated { get; set; }
+
+        [JsonProperty("cases")]
+        public int Cases { get; set; }
+
+        [JsonProperty("todayCases")]
+        public int TodayCases { get; set; }
+
+        [JsonProperty("deaths")]
+        public int Deaths { get; set; }
+
+        [JsonProperty("todayDeaths")]
+        public int TodayDeaths { get; set; }
+
+        [JsonProperty("recovered")]
+        public int Recovered { get; set; }
+
+        [JsonProperty("todayRecovered")]
+        public int TodayRecovered { get; set; }
+
+        [JsonProperty("active")]
+        public int Active { get; set; }
+
+        [JsonProperty("critical")]
+        public int Critical { get; set; }
+
+        [JsonProperty("casesPerOneMillion")]
+        public double CasesPerOneMillion { get; set; }
+
+        [JsonProperty("deathsPerOneMillion")]
+        public double DeathsPerOneMillion { get; set; }
+
+        [JsonProperty("tests")]
+        public int Tests { get; set; }
+
+        [JsonProperty("testsPerOneMillion")]
+        public double TestsPerOneMillion { get; set; }
+
+        [JsonProperty("population")]
+        public long Population { get; set; }
+
+        [JsonProperty("oneCasePerPeople")]
+        public double OneCasePerPeople { get; set; }
+
+        [JsonProperty("oneDeathPerPeople")]
+        public double OneDeathPerPeople { get; set; }
+
+        [JsonProperty("oneTestPerPeople")]
+        public double OneTestPerPeople { get; set; }
+
+        [JsonProperty("activePerOneMillion")]
+        public double ActivePerOneMillion { get; set; }
+
+        [JsonProperty("recoveredPerOneMillion")]
+        public double RecoveredPerOneMillion { get; set; }
+
+        [JsonProperty("criticalPerOneMillion")]
+        public double CriticalPerOneMillion { get; set; }
+
+        [JsonProperty("affectedCountries")]
+        public int AffectedCountries { get; set; }
+    }
+}

--- a/Modules/UserCommands.cs
+++ b/Modules/UserCommands.cs
@@ -1,4 +1,9 @@
-﻿using Discord.Commands;
+﻿using CouchBot.UserCommands.Models;
+using Discord.Commands;
+using Newtonsoft.Json;
+using System;
+using System.Net.Http;
+using System.Threading.Tasks;
 
 namespace CouchBot.UserCommands.Modules
 {
@@ -17,5 +22,52 @@ namespace CouchBot.UserCommands.Modules
         //{
         //    return ReplyAsync("Your Return Text!");
         //}
+
+
+        [Command("covid", RunMode = RunMode.Async)]
+        [Alias("covid status", "covid stats", "covid news", "covid today", "covid updates", "corona", "coronavirus")]
+        [Summary("returns the latest covid cases cases updates using public API")]
+        public Task GetCovidDataAsync()
+        {
+            try
+            {
+                using (var client = new HttpClient())
+                {
+                    client.BaseAddress = new Uri("https://corona.lmao.ninja/");
+                    var response = client.GetAsync("v2/all").GetAwaiter().GetResult();
+
+                    if (response.IsSuccessStatusCode)
+                    {
+                        var data = response.Content.ReadAsStringAsync().GetAwaiter().GetResult();
+                        CovidData covidData = JsonConvert.DeserializeObject<CovidData>(data);
+
+                        Random random = new Random();
+                        var number = random.Next(1, 4);
+
+                        switch (number)
+                        {
+                            case 1:
+                                return ReplyAsync(string.Format("Out of {0} total cases, {1} were reported today.",
+                                covidData.Cases, covidData.TodayCases));
+                            case 2:
+                                return ReplyAsync(string.Format("Out of {0} deaths, {1} were died today.",
+                                covidData.Deaths, covidData.TodayDeaths));
+                            default:
+                                return ReplyAsync(string.Format("Great news! {0} people recovered today.",
+                                covidData.Cases, covidData.TodayCases));
+                        }
+                    }
+                    else
+                    {
+                        return ReplyAsync("I'm feeling dizzy");
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                return ReplyAsync("I'm exhausted");
+            }
+
+        }
     }
 }

--- a/Modules/UserCommands.cs
+++ b/Modules/UserCommands.cs
@@ -54,7 +54,7 @@ namespace CouchBot.UserCommands.Modules
                                 covidData.Deaths, covidData.TodayDeaths));
                             default:
                                 return ReplyAsync(string.Format("Great news! {0} people recovered today.",
-                                covidData.Cases, covidData.TodayCases));
+                                covidData.TodayRecovered));
                         }
                     }
                     else


### PR DESCRIPTION
feature #1 - Added command to get COVID updates using a public API

command - "covid"
alias - "covid status", "covid stats", "covid news", "covid today", "covid updates", "corona", "coronavirus"

The working of the command

![image](https://user-images.githubusercontent.com/15251751/95665194-a6a26980-0b6b-11eb-82a0-7448cf46251d.png)
